### PR TITLE
Add metrics to round status

### DIFF
--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -92,6 +92,7 @@ class Aggregator:
         self.logger = getLogger(__name__)
         self.write_logs = write_logs
         self.log_metric_callback = log_metric_callback
+        self.metrics = []
 
         self.straggler_handling_policy = (
             straggler_handling_policy or CutoffTimeBasedStragglerHandling()
@@ -674,6 +675,7 @@ class Aggregator:
                     'metric_value': float(value),
                 }
                 self.metric_queue.put(metrics)
+                self.metrics.append(metrics)
                 self.logger.metric("%s", str(metrics))
 
             task_results.append(tensor_key)
@@ -979,6 +981,7 @@ class Aggregator:
                         f'Aggregated metric {agg_tensor_key} could not be collected '
                         f'for round {self.round_number}. Skipping reporting for this round')
                 self.metric_queue.put(metrics)
+                self.metrics.append(metrics)
                 self.logger.metric("%s", metrics)
 
                 # FIXME: Configurable logic for min/max criteria in saving best.
@@ -993,6 +996,7 @@ class Aggregator:
                 self._prepare_trained(tensor_name, origin, round_number, report, agg_results)
 
     def _get_round_status(self):
+
         status = {
             "round": self.round_number,
             "round_start": self.first_col_start,
@@ -1004,6 +1008,7 @@ class Aggregator:
             "to_remove_next_round": self.collaborators_to_remove,
             "available_collaborators": self.available_collaborators,
             "assigned_collaborators": self.assigner.get_assigned_collaborators() or [],
+            "metrics": self.metrics,
         }
         return status
 
@@ -1013,6 +1018,7 @@ class Aggregator:
 
         Returns experiment status for the current and previous rounds.
         """
+        self._retrieve_metrics()
         current_round_status = self._get_round_status()
         previous_round_status = self.previous_round_status
         return current_round_status, previous_round_status
@@ -1159,6 +1165,8 @@ class Aggregator:
         self.available_collaborators = []
         # resetting collaborators_done for next round
         self.collaborators_done = []
+        # resetting tracked metrics results for next round
+        self.metrics = []
 
         # Save the latest model
         self.logger.info(f'Saving round {self.round_number} model...')

--- a/openfl/component/aggregator/aggregator.py
+++ b/openfl/component/aggregator/aggregator.py
@@ -1018,7 +1018,6 @@ class Aggregator:
 
         Returns experiment status for the current and previous rounds.
         """
-        self._retrieve_metrics()
         current_round_status = self._get_round_status()
         previous_round_status = self.previous_round_status
         return current_round_status, previous_round_status

--- a/openfl/protocols/aggregator.proto
+++ b/openfl/protocols/aggregator.proto
@@ -167,6 +167,7 @@ message ExperimentStatus {
   repeated string to_remove_next_round = 6;
   repeated string available_collaborators = 7;
   repeated string assigned_collaborators = 8;
+  repeated GetMetricStreamResponse metrics = 9;
 }
 
 message GetExperimentStatusResponse {

--- a/openfl/transport/grpc/aggregator_server.py
+++ b/openfl/transport/grpc/aggregator_server.py
@@ -353,6 +353,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
         to_remove_next_round = status_dict["to_remove_next_round"]
         available_collaborators = status_dict["available_collaborators"]
         assigned_collaborators = status_dict["assigned_collaborators"]
+        metrics = status_dict["metrics"]
+        metrics = [aggregator_pb2.GetMetricStreamResponse(**metric) for metric in metrics]
 
         collaborators_progress = []
         for collaborator_name in collaborators:
@@ -369,6 +371,7 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             )
             collaborators_progress.append(collaborator_progress_pb)
 
+
         return aggregator_pb2.ExperimentStatus(
             round=round_num,
             round_start=round_start,
@@ -377,7 +380,8 @@ class AggregatorGRPCServer(aggregator_pb2_grpc.AggregatorServicer):
             to_add_next_round=to_add_next_round,
             to_remove_next_round=to_remove_next_round,
             available_collaborators=available_collaborators,
-            assigned_collaborators=assigned_collaborators
+            assigned_collaborators=assigned_collaborators,
+            metrics=metrics,
         )
 
     def GetExperimentStatus(self, request, context):  # NOQA:N802

--- a/openfl/utilities/utils.py
+++ b/openfl/utilities/utils.py
@@ -187,6 +187,17 @@ def convert_experiment_status_proto_to_dict(response):
     def convert_task_end_times(tasks):
         return [{"task_name": task.task_name, "end_time": task.end_time} for task in tasks]
 
+    def convert_metrics(metrics):
+        return [
+            {
+                "metric_origin": metric.metric_origin,
+                "task_name": metric.task_name,
+                "metric_name": metric.metric_name,
+                "metric_value": metric.metric_value,
+                "round": metric.round,
+            } for metric in metrics
+        ]
+
     def convert_collaborators_progress(collaborators):
         return [
             {
@@ -209,7 +220,8 @@ def convert_experiment_status_proto_to_dict(response):
             "to_add_next_round": list(round_status.to_add_next_round),
             "to_remove_next_round": list(round_status.to_remove_next_round),
             "available_collaborators": list(round_status.available_collaborators),
-            "assigned_collaborators": list(round_status.assigned_collaborators)
+            "assigned_collaborators": list(round_status.assigned_collaborators),
+            "metrics": convert_metrics(round_status.metrics),
         }
 
     current_round_dict = convert_experiment_status(response.current_round)


### PR DESCRIPTION
This PR adds performance metrics obtained from collaborators, as well as aggregated ones, to the round_status dictionary.